### PR TITLE
Fix unformatted code blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,17 +407,20 @@ Starting from the kube-state-metrics chart `v2.13.3` (kube-state-metrics image `
 
 #### Development
 
-When developing, test a metric dump against your local Kubernetes cluster by
-running:
+When developing, test a metric dump against your local Kubernetes cluster by running:
 
 > Users can override the apiserver address in KUBE-CONFIG file with `--apiserver` command line.
 
- go install
- kube-state-metrics --port=8080 --telemetry-port=8081 --kubeconfig=<KUBE-CONFIG> --apiserver=<APISERVER>
+```
+go install
+kube-state-metrics --port=8080 --telemetry-port=8081 --kubeconfig=<KUBE-CONFIG> --apiserver=<APISERVER>
+```
 
 Then curl the metrics endpoint
 
- curl localhost:8080/metrics
+```
+curl localhost:8080/metrics
+```
 
 To run the e2e tests locally see the documentation in [tests/README.md](./tests/README.md).
 


### PR DESCRIPTION
**What this PR does / why we need it**: there were a couple of unformatted code blocks on the README that just triggered my OCD. This makes the fact that it is meant to run in the terminal more explicit. 

**How does this change affect the cardinality of KSM**: *does not change cardinality*